### PR TITLE
fix: config fails to parse on Nextflow 26 (V2 config parser)

### DIFF
--- a/conf/constants.config
+++ b/conf/constants.config
@@ -1,5 +1,5 @@
 params {
-    CONSTANTS {
-        FASTA_COLUMN = "input_fasta"
-    }
+    CONSTANTS = [
+        FASTA_COLUMN: "input_fasta"
+    ]
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -528,21 +528,36 @@ validation {
 \033[0;32m ,-',' `.`-.\033[0;34m    | |__| | | | \\ \\   / ____ \\  | |  | |    \033[0;32m,-',' `.`-.         \033[0m
 \033[0;32m(==(     )==)\033[0;34m   |_____/  |_|  \\_\\ /_/    \\_\\ |_|  |_|   \033[0;32m(==(     )==)       \033[0m
 
-\033[0;35m  ${manifest.name} ${manifest.version}\033[0m
+\033[0;35m  WrightonLabCSU/dram\033[0m
 \033[2m=====================================================================\033[0m
 
 In addition to the parameters below, there are many Nextflow specific parameters that you may find useful, such as `-profile` to select a configuration profile, `-resume` to restart from a previous run, and `-c` to specify a custom config file.
 See `nextflow run -help` for more information, or https://nextflow.io/docs/latest/config.html and https://nextflow.io/docs/latest/cache-and-resume.html for good places to start looking.
 Also see the DRAM nextflow.config file and documentation for a full list of all profiles, which include dependency management options (e.g. conda, docker, singularity, etc.), as well as run modes (full_mode, etc.)
 """
-        afterText = """${manifest.doi ? "* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "  https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
+        afterText = """
 * Software dependencies
-    https://github.com/${manifest.name}/blob/master/CITATIONS.md
+    https://github.com/WrightonLabCSU/dram/blob/master/CITATIONS.md
 """
     }
     summary {
-        beforeText = validation.help.beforeText
-        afterText = validation.help.afterText
+        beforeText = """
+\033[2m=====================================================================                     \033[0m
+                                                                                                 \033[0m
+\033[0;34m                 _____    _____               __  __                                    \033[0m
+\033[0;32m(==(     )==)\033[0;34m   |  __ \\  |  __ \\      /\\     |  \\/  |   \033[0;32m(==(     )==)     \033[0m
+\033[0;32m `-.`. ,',-'\033[0;34m    | |  | | | |__) |    /  \\    | \\  / |    \033[0;32m`-.`. ,',-'         \033[0m
+\033[0;32m    _,-'"\033[0;34m       | |  | | |  _  /    / /\\ \\   | |\\/| |       \033[0;32m_,-'"            \033[0m
+\033[0;32m ,-',' `.`-.\033[0;34m    | |__| | | | \\ \\   / ____ \\  | |  | |    \033[0;32m,-',' `.`-.         \033[0m
+\033[0;32m(==(     )==)\033[0;34m   |_____/  |_|  \\_\\ /_/    \\_\\ |_|  |_|   \033[0;32m(==(     )==)       \033[0m
+
+\033[0;35m  WrightonLabCSU/dram\033[0m
+\033[2m=====================================================================\033[0m
+"""
+        afterText = """
+* Software dependencies
+    https://github.com/WrightonLabCSU/dram/blob/master/CITATIONS.md
+"""
     }
 }
 


### PR DESCRIPTION
## Problem

DRAM declares `nextflowVersion = '!>=24'`, but on Nextflow 26.04 the pipeline cannot launch at all. Config parsing fails with 8 errors before the workflow starts:

```
Error nextflow.config:531:15: `manifest` is not defined
Error nextflow.config:544:22: `validation` is not defined
```

The V2 config parser resolves scopes statically and rejects cross-scope references that V1 resolved lazily at runtime. Two constructs trigger it:

- `validation.help` interpolates `manifest.name` / `manifest.version` / `manifest.doi` from the sibling `manifest` scope
- `validation.summary` assigns from `validation.help.beforeText` / `afterText`

On 24.10.5 the same config parses fine, so this is a new-Nextflow break rather than something long-standing.

## Fix

The references are inlined as literals. There is no DRY alternative: V2 also forbids variable declarations in config files, so a shared `def` for the pipeline name fails with *"Variable declarations cannot be mixed with config statements"* — both in place and hoisted to the top of the file.

`conf/constants.config` separately used a nested closure inside `params`:

```groovy
params { CONSTANTS { FASTA_COLUMN = "input_fasta" } }
```

V1 promoted that to a Map. It is switched to an explicit Map literal so the shape is a Map under both parsers. Ten modules plus `workflows/dram.nf` read `params.CONSTANTS.FASTA_COLUMN`, and attribute access is identical on either.

## Verified

| | before | after |
|---|---|---|
| `nextflow config .` on 26.04 | 8 errors | exit 0, no errors |
| `nextflow config .` on 24.10.5 | exit 0 | exit 0 |

So the supported floor does not regress. Diffing the fully resolved config on 24.10.5 before and after, the only differences are the `CONSTANTS` representation and the two banner changes below. `validation.help.afterText` comes out byte-identical, which confirms the dropped `manifest.doi` branches always rendered empty (`doi = ''`).

I have not run the pipeline end to end for this — the check is config parsing only.

## Two user-visible changes, both banner text

1. **The help and summary banners no longer print the version.** Inlining it as a literal would duplicate `manifest.version` and silently go stale at the next release, which seemed worse than omitting it. If you want it back, the durable place is the Groovy side where `workflow.manifest` is reachable — which is also where the current nf-core template puts it.
2. **`validation.summary.beforeText` now carries the ASCII banner only.** Previously it aliased the whole of `validation.help.beforeText`, which also pulled the help-specific prose (*"In addition to the parameters below..."*) into the run summary, where it does not apply. The ASCII art itself is preserved.

Happy to change either if the previous behaviour was intended.

## Deliberately left out

Both are judgement calls rather than launch blockers, so I did not want to bundle them:

- **nf-schema 2.1.1 does not register the `validation` scope under V2**, so 10 `Unrecognized config option validation.*` warnings remain and the help/summary customisation is inert there. Fixing that means bumping nf-schema, which changes validation behaviour. This PR takes the pipeline from *fatal* to *runs with warnings*; it does not make the help customisation take effect on 26.04.
- **`boost { cleanup = false }`** references a scope from an nf-boost plugin that is not in the `plugins` block, producing one more warning.

Glad to follow up with either if you want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
